### PR TITLE
removed pass phrase, fixed cert filename

### DIFF
--- a/4-12.md
+++ b/4-12.md
@@ -31,7 +31,7 @@
 
 2. Сгенерируйте сертификат для него указав `localhost` в качестве `CN`.
 
-`sudo openssl req -x509 -newkey rsa:4096 -keyout /etc/nginx/cert.key -out /etc/nginx/cert.pem -days 365`
+`sudo openssl req -x509 -nodes -newkey rsa:4096 -keyout /etc/nginx/cert.key -out /etc/nginx/cert.pem -days 365`
 
 3. Отредактируйте модуль `http` в файле `/etc/nginx/nginx.conf`.
 
@@ -43,7 +43,7 @@ http {
         root   /var/www/public;
         listen  443 ssl http2 default_server;
         server_name  localhost;
-        ssl_certificate  /etc/nginx/cert.crt;
+        ssl_certificate  /etc/nginx/cert.pem;
         ssl_certificate_key /etc/nginx/cert.key;
         ssl_protocols   TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers   HIGH:!aNULL:!MD5;


### PR DESCRIPTION
Из команды генерации ключа и сертификата убран запрос пассфразы для ключа.
В конфигурации nginx изменено имя файла сертификата в соответствии с сгенерированным командой выше.